### PR TITLE
Redisが使える装備と一通りのサンプルを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ project/plugins/project/
 .gradle/
 build/
 
+# what's ?
+/classes/
+

--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 
     compile 'org.scala-lang:scala-library:2.11.8'
     compile 'org.springframework.boot:spring-boot-starter-web'
+    compile 'org.springframework.boot:spring-boot-starter-redis'
 
     testCompile 'org.springframework.boot:spring-boot-starter-test'
     testCompile 'org.specs2:specs2-core_2.11:3.8.6'
@@ -33,5 +34,5 @@ dependencies {
 
 // specs2の"nUnit形式テキストファイル"の出し先が「maven形式の吐き先」になってるので、上書き設定。
 test {
-    systemProperty "stats.outdir" , "$buildDir/specs2-reports/status"
+    systemProperty "stats.outdir", "$buildDir/specs2-reports/status"
 }

--- a/doc/REFERENCE_PUBS.md
+++ b/doc/REFERENCE_PUBS.md
@@ -15,3 +15,4 @@
 
 - [クライアントからCLIで参照](http://qiita.com/sawada_masahiko/items/1f60936c421ecab8dfbf)
 - [CLIでのコマンド一覧](http://qiita.com/rubytomato@github/items/d66d932959d596876ab5)
+- [Dockerで「Redisサーバ」公式イメージ](https://hub.docker.com/_/redis/)

--- a/doc/REFERENCE_PUBS.md
+++ b/doc/REFERENCE_PUBS.md
@@ -10,6 +10,9 @@
 
 - [ScalaでSpringBootやってる例(sbtだけど)](http://mao-instantlife.hatenablog.com/entry/2015/09/07/SpringBoot%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%92Scala_%2B_sbt%E3%81%A7%E6%A7%8B%E7%AF%89%E3%81%99%E3%82%8B)
 
+## Spring
+
+- [コード上だけでSpringDIする方法(等)](http://www.atmarkit.co.jp/ait/articles/0504/29/news022_2.html)
 
 ## Redis
 

--- a/doc/REFERENCE_PUBS.md
+++ b/doc/REFERENCE_PUBS.md
@@ -14,6 +14,10 @@
 
 - [コード上だけでSpringDIする方法(等)](http://www.atmarkit.co.jp/ait/articles/0504/29/news022_2.html)
 
+## Specs2
+
+- [実行順序ではまらないようにする的なハナシ](http://sui.hateblo.jp/entry/2013/07/21/011958)
+
 ## Redis
 
 - [クライアントからCLIで参照](http://qiita.com/sawada_masahiko/items/1f60936c421ecab8dfbf)

--- a/doc/REFERENCE_PUBS.md
+++ b/doc/REFERENCE_PUBS.md
@@ -9,3 +9,9 @@
 ## Scala & SpringBoot
 
 - [ScalaでSpringBootやってる例(sbtだけど)](http://mao-instantlife.hatenablog.com/entry/2015/09/07/SpringBoot%E3%83%97%E3%83%AD%E3%82%B8%E3%82%A7%E3%82%AF%E3%83%88%E3%82%92Scala_%2B_sbt%E3%81%A7%E6%A7%8B%E7%AF%89%E3%81%99%E3%82%8B)
+
+
+## Redis
+
+- [クライアントからCLIで参照](http://qiita.com/sawada_masahiko/items/1f60936c421ecab8dfbf)
+- [CLIでのコマンド一覧](http://qiita.com/rubytomato@github/items/d66d932959d596876ab5)

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -1,0 +1,10 @@
+spring.redis:
+  host: localhost
+  port: 6379
+  password: null
+  database: 0
+  pool:
+    max-idle: 8
+    min-idle: 0
+    max-active: 8
+    max-wait: -1

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepository.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepository.scala
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Repository
 class SampleRedisRepository {
 
   /** Redisで取得するキー */
-  val SAMPLE_KEY = "sanple-value:string"
+  val SAMPLE_KEY = "sample-value:string"
 
   @Autowired
   private val redisTemplate: StringRedisTemplate = null

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepository.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepository.scala
@@ -1,0 +1,10 @@
+package com.github.kazuhito_m.twitterbattler.primitive.domain
+
+import org.springframework.stereotype.Repository
+
+@Repository
+class SampleRedisRepository {
+
+  def getSampleValue: String = "Redisのテストに使う予定の建設予定地。ここでは値取得だけ。";
+
+}

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepository.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepository.scala
@@ -1,10 +1,37 @@
 package com.github.kazuhito_m.twitterbattler.primitive.domain
 
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.data.redis.core.StringRedisTemplate
 import org.springframework.stereotype.Repository
 
 @Repository
 class SampleRedisRepository {
 
-  def getSampleValue: String = "Redisのテストに使う予定の建設予定地。ここでは値取得だけ。";
+  /** Redisで取得するキー */
+  val SAMPLE_KEY = "sanple-value:string"
+
+  @Autowired
+  private val redisTemplate: StringRedisTemplate = null
+
+  /**
+    * サンプル用テキトウキーで値を取得。
+    *
+    * @return 取得できた値。
+    */
+  def getSampleValue: String = ofv.get(SAMPLE_KEY)
+
+  /**
+    * サンプル用テキトウキーで値を保存。
+    *
+    * @param value 保存する文字列。
+    */
+  def setSampleValue(value: String) = ofv.set(SAMPLE_KEY, value)
+
+  /**
+    * サンプル用テキトウキー自体を削除。
+    */
+  def clearSampleValue = redisTemplate.delete(SAMPLE_KEY)
+
+  private def ofv = redisTemplate.opsForValue()
 
 }

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
@@ -1,16 +1,21 @@
 package com.github.kazuhito_m.twitterbattler.primitive.view
 
+import com.github.kazuhito_m.twitterbattler.primitive.domain.SampleRedisRepository
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.web.bind.annotation.{RequestMapping, RequestMethod, RestController}
 
 @RestController
 @RequestMapping(Array("/sample"))
 class SampleController {
 
+  @Autowired
+  var redisRepo: SampleRedisRepository = null
+
   @RequestMapping(value = Array("test"), method = Array(RequestMethod.GET))
   def data = "hoge"
 
 
   @RequestMapping(value = Array("redisgetsample"), method = Array(RequestMethod.GET))
-  def redisGetSample(): String = "Redisのテストに使う予定の建設予定地。"
+  def redisGetSample(): String = redisRepo.getSampleValue
 
 }

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
@@ -3,13 +3,14 @@ package com.github.kazuhito_m.twitterbattler.primitive.view
 import org.springframework.web.bind.annotation.{RequestMapping, RequestMethod, RestController}
 
 @RestController
+@RequestMapping(Array("/sample"))
 class SampleController {
 
-  @RequestMapping(value = Array("/api/sample"), method = Array(RequestMethod.GET))
+  @RequestMapping(value = Array("test"), method = Array(RequestMethod.GET))
   def data = "hoge"
 
 
-  @RequestMapping(value = Array("/api/redisgetsample"), method = Array(RequestMethod.GET))
+  @RequestMapping(value = Array("redisgetsample"), method = Array(RequestMethod.GET))
   def redisGetSample(): String = "Redisのテストに使う予定の建設予定地。"
 
 }

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
@@ -3,8 +3,13 @@ package com.github.kazuhito_m.twitterbattler.primitive.view
 import org.springframework.web.bind.annotation.{RequestMapping, RequestMethod, RestController}
 
 @RestController
-@RequestMapping(Array("/api/sample"))
 class SampleController {
-  @RequestMapping(method = Array(RequestMethod.GET))
+
+  @RequestMapping(value = Array("/api/sample"), method = Array(RequestMethod.GET))
   def data = "hoge"
+
+
+  @RequestMapping(value = Array("/api/redisgetsample"), method = Array(RequestMethod.GET))
+  def redisGetSample(): String = "Redisのテストに使う予定の建設予定地。"
+
 }

--- a/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
+++ b/src/main/scala/com/github/kazuhito_m/twitterbattler/primitive/view/SampleController.scala
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.{RequestMapping, RequestMethod, R
 class SampleController {
 
   @Autowired
-  var redisRepo: SampleRedisRepository = null
+  val redisRepo: SampleRedisRepository = null
 
   @RequestMapping(value = Array("test"), method = Array(RequestMethod.GET))
   def data = "hoge"

--- a/src/test/resources/config/application.yml
+++ b/src/test/resources/config/application.yml
@@ -1,0 +1,10 @@
+spring.redis:
+  host: localhost
+  port: 6379
+  password: null
+  database: 0
+  pool:
+    max-idle: 8
+    min-idle: 0
+    max-active: 8
+    max-wait: -1

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/ConfigForTest.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/ConfigForTest.scala
@@ -1,0 +1,7 @@
+package com.github.kazuhito_m.twitterbattler.primitive
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+
+@SpringBootApplication
+class ConfigForTest {
+}

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
@@ -1,6 +1,6 @@
 package com.github.kazuhito_m.twitterbattler.primitive.domain
 
-import com.github.kazuhito_m.twitterbattler.primitive.fw.TestHelper
+import com.github.kazuhito_m.twitterbattler.primitive.fw.TestHelper._
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
@@ -9,12 +9,11 @@ import org.specs2.runner.JUnitRunner
 @RunWith(classOf[JUnitRunner])
 class SampleRedisRepositoryTest extends Specification {
 
-  // Springアノテーション系が全滅してるので、自力でコンテキスト作ってその場で動かす。
-  var sut: SampleRedisRepository = TestHelper.beanBy(classOf[SampleRedisRepository]);
+  val sut = beanBy(classOf[SampleRedisRepository])
 
   "サンプルのドメインクラスのお試しテスト" should {
 
-    "RESTから代表的な値を取ってくることが出来る" in {
+    "Redisから代表的な値を取ってくることが出来る" in {
       sut.getSampleValue must equalTo("Redisのテストに使う予定の建設予定地。ここでは値取得だけ。")
     }
 

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
@@ -4,17 +4,34 @@ import com.github.kazuhito_m.twitterbattler.primitive.fw.TestHelper._
 import org.junit.runner.RunWith
 import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
+import org.specs2.specification.BeforeEach
 
 
 @RunWith(classOf[JUnitRunner])
-class SampleRedisRepositoryTest extends Specification {
+class SampleRedisRepositoryTest extends Specification with BeforeEach {
+
+  // befere -> test という風に実行順を保証する記述。
+  sequential
 
   val sut = beanBy(classOf[SampleRedisRepository])
 
+  def before = {
+    sut.clearSampleValue // 初期設定
+  }
+
   "サンプルのドメインクラスのお試しテスト" should {
 
-    "Redisから代表的な値を取ってくることが出来る" in {
-      sut.getSampleValue must equalTo("Redisのテストに使う予定の建設予定地。ここでは値取得だけ。")
+    "初期状態はnull" in {
+      sut.getSampleValue must beNull
+    }
+
+    "値を放り込んで、取得できる" in {
+      val expect = "Redisから代表的な値を取ってくることが出来る"
+
+      sut.setSampleValue(expect)
+      val actual = sut.getSampleValue
+
+      actual must equalTo(expect)
     }
 
   }

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
@@ -6,7 +6,6 @@ import org.specs2.mutable.Specification
 import org.specs2.runner.JUnitRunner
 import org.specs2.specification.BeforeEach
 
-
 @RunWith(classOf[JUnitRunner])
 class SampleRedisRepositoryTest extends Specification with BeforeEach {
 

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/domain/SampleRedisRepositoryTest.scala
@@ -1,0 +1,23 @@
+package com.github.kazuhito_m.twitterbattler.primitive.domain
+
+import com.github.kazuhito_m.twitterbattler.primitive.fw.TestHelper
+import org.junit.runner.RunWith
+import org.specs2.mutable.Specification
+import org.specs2.runner.JUnitRunner
+
+
+@RunWith(classOf[JUnitRunner])
+class SampleRedisRepositoryTest extends Specification {
+
+  // Springアノテーション系が全滅してるので、自力でコンテキスト作ってその場で動かす。
+  var sut: SampleRedisRepository = TestHelper.beanBy(classOf[SampleRedisRepository]);
+
+  "サンプルのドメインクラスのお試しテスト" should {
+
+    "RESTから代表的な値を取ってくることが出来る" in {
+      sut.getSampleValue must equalTo("Redisのテストに使う予定の建設予定地。ここでは値取得だけ。")
+    }
+
+  }
+
+}

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/fw/TestHelper.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/fw/TestHelper.scala
@@ -1,6 +1,6 @@
 package com.github.kazuhito_m.twitterbattler.primitive.fw
 
-import com.github.kazuhito_m.twitterbattler.primitive.Application
+import com.github.kazuhito_m.twitterbattler.primitive.ConfigForTest
 import org.springframework.context.annotation.AnnotationConfigApplicationContext
 
 /**
@@ -10,7 +10,7 @@ import org.springframework.context.annotation.AnnotationConfigApplicationContext
   */
 object TestHelper {
 
-  val applicationContext = new AnnotationConfigApplicationContext(classOf[Application])
+  val applicationContext = new AnnotationConfigApplicationContext(classOf[ConfigForTest])
 
   /**
     * 指定したクラスのDI済Beanを取得する。

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/fw/TestHelper.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/fw/TestHelper.scala
@@ -1,0 +1,17 @@
+package com.github.kazuhito_m.twitterbattler.primitive.fw
+
+import com.github.kazuhito_m.twitterbattler.primitive.Application
+import org.springframework.context.annotation.AnnotationConfigApplicationContext
+
+/**
+  * Test用の色々ヘルパー。
+  *
+  * 主だった目的は「Specs2のテストにDI出来ない」ため、それを補うための装備を持つ。
+  */
+object TestHelper {
+
+  val applicationContext = new AnnotationConfigApplicationContext(classOf[Application])
+
+  def beanBy[T](target: Class[T]): T = applicationContext.getBean(target)
+
+}

--- a/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/fw/TestHelper.scala
+++ b/src/test/scala/com/github/kazuhito_m/twitterbattler/primitive/fw/TestHelper.scala
@@ -12,6 +12,15 @@ object TestHelper {
 
   val applicationContext = new AnnotationConfigApplicationContext(classOf[Application])
 
-  def beanBy[T](target: Class[T]): T = applicationContext.getBean(target)
+  /**
+    * 指定したクラスのDI済Beanを取得する。
+    *
+    * Scala+Specs2+Gradleなテストでは「アノテーションによるSpringDIが出来ない」ので、自力でやる。
+    *
+    * @param clazz 対象となるクラス。
+    * @tparam T 対象と成るクラス型。
+    * @return 取得できたBean。
+    */
+  def beanBy[T](clazz: Class[T]): T = applicationContext.getBean(clazz)
 
 }

--- a/startup_db.sh
+++ b/startup_db.sh
@@ -6,3 +6,5 @@
 # - dockerが使える
 
 docker run --name tbp-db -p 6379:6379 -d redis:3.2.5-alpine
+
+# この後は、redis-cli 入ってるなら、`redis-cli --raw` で中身を覗いてください。

--- a/startup_db.sh
+++ b/startup_db.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# このアプリ用のデータベースを開始するスクリプト
+# 前提は
+# - Linuxである
+# - dockerが使える
+
+docker run --name tbp-db -p 6379:6379 -d redis:3.2.5-alpine


### PR DESCRIPTION
掲題の通り。

ライブラリは `spring-boot-starter-redis` の `RedisTemplate` を生で使うこととした。

TODO : 物足りなくなれば `Sedis` を入れてラップ出来ないかを検討する

その他のトピックは以下。

- 参照資料リンクを追加
- 設定を「テスト用」と「実行時用」に一応分ける
  - ただし「テスト実行/webアプリ実行」なだけでローカルと本番ということではない
- 各種パッケージ移動
- コントローラの@RequestMappingのURLを変更+階層構造に
- SpringDIがテストで使えるよう改造
  - アノテーションを使えなかったのでソレ用のHelper作成
- RedisサーバをローカルのDockerで立ち上げるスクリプトを追加

fixes #6